### PR TITLE
feat(search): add threefold repetition detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ designed to analyse games for the Castled Chess Project.
     - Principal Variation Search
     - Reverse Futility Pruning
     - Quiescence Search
+    - Draw & Checkmate Detection
 - Evaluation
     - Pesto Evaluation
 - Move Generation using [shakmaty](https://github.com/niklasf/shakmaty)


### PR DESCRIPTION
## SPRT (vs main)

```
Score of CastledChessDev vs CastledChessMain: 45 - 12 - 43 [0.665]
...      CastledChessDev playing White: 24 - 5 - 21  [0.690] 50
...      CastledChessDev playing Black: 21 - 7 - 22  [0.640] 50
...      White vs Black: 31 - 26 - 43  [0.525] 100
Elo difference: 119.1 +/- 52.3, LOS: 100.0 %, DrawRatio: 43.0 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
100 of 100 games finished.

Player: CastledChessDev
   "Draw by 3-fold repetition": 39
   "Draw by fifty moves rule": 1
   "Draw by insufficient mating material": 3
   "Loss: Black mates": 5
   "Loss: White mates": 7
   "Win: Black mates": 21
   "Win: White mates": 24
Player: CastledChessMain
   "Draw by 3-fold repetition": 39
   "Draw by fifty moves rule": 1
   "Draw by insufficient mating material": 3
   "Loss: Black mates": 21
   "Loss: White mates": 24
   "Win: Black mates": 5
   "Win: White mates": 7
```