### PR TITLE
improve(time-management): estimate time taken by next depth

### DIFF
--- a/engine/src/search/search.rs
+++ b/engine/src/search/search.rs
@@ -13,6 +13,7 @@ use crate::principal_variation::PvTable;
 use crate::search::search_info::SearchInfo;
 use crate::search::search_params::SearchParams;
 use crate::time_control::time_controller::TimeController;
+use crate::time_control::time_mode::TimeMode;
 use crate::transposition::{TranspositionTable, TranspositionTableEntry};
 use crate::uci::UciMode;
 use shakmaty::zobrist::{Zobrist64, ZobristHash};
@@ -160,6 +161,12 @@ impl Search {
 
         /* Iterative deepening */
         for current_depth in 0..self.params.depth {
+            if TimeMode::is_finite(&self.time_controller.time_mode)
+                && (self.time_controller.elapsed() * 2) as u128 > self.time_controller.play_time
+            {
+                break;
+            }
+
             self.info.depth = current_depth + 1;
             let pos = self.game.clone();
             let iteration_score = self.negamax(&pos, self.info.depth, -100000, 100000, 0);

--- a/engine/src/time_control/time_controller.rs
+++ b/engine/src/time_control/time_controller.rs
@@ -1,7 +1,7 @@
-use chrono::Local;
-use shakmaty::{Chess, Color, Position};
 use crate::search::search_params::SearchParams;
 use crate::time_control::time_mode::TimeMode;
+use chrono::Local;
+use shakmaty::{Chess, Color, Position};
 
 /// Manages time control for chess engine operations.
 /// Handles different time modes and tracks elapsed time during search.
@@ -11,7 +11,7 @@ pub struct TimeController {
     /// Timestamp when search started
     start_time: i64,
     /// Allocated time for current search in milliseconds
-    play_time: u128,
+    pub play_time: u128,
 }
 
 impl TimeController {
@@ -30,9 +30,9 @@ impl TimeController {
             TimeMode::MoveTime => params.move_time,
             TimeMode::WOrBTime => match game.turn() {
                 Color::White => params.w_time / 30,
-                Color::Black => params.b_time / 30
+                Color::Black => params.b_time / 30,
             },
-            _ => 0
+            _ => 0,
         };
 
         self.start();
@@ -68,3 +68,4 @@ impl Default for TimeController {
         }
     }
 }
+


### PR DESCRIPTION
Stops the search early if the estimated time taken for the next depth (time taken * 2) surpasses the allocated time

Bench: https://openbench.castled.app/test/36/ & https://openbench.castled.app/test/35/